### PR TITLE
Adding python wrapper (py-carbone-connect) lib to the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Embedded Carbone in a Docker image with simple REST API.
 
 ## How to consume exposed API ?
-The simpliest way to use this image is to use `node` and install [`carbone-connect` package](https://npmjs.org/carbone-connect).
+The simpliest way to use this image is to use `node` and install [`carbone-connect` package](https://npmjs.org/carbone-connect). If you need a Python wrapper you can follow to this [`repo py-carbone-connect`](https://github.com/Piuliss/py-carbone-connect), really easy to use and play.
 
 ## From carbone.io website
 _Fast, Simple and Powerful report generator in any format PDF, DOCX, XLSX, ODT, PPTX, ODS [, ...]_


### PR DESCRIPTION
# Python Wrapper for Carbone API

## Overview
I've developed a Python client wrapper for the Carbone API to facilitate seamless integration with Python projects. The implementation provides a clean, type-hinted interface for interacting with Carbone's document generation services.

## Current Features
- Full TypeScript to Python implementation
- Type hints support for better IDE integration
- Proper error handling with custom exceptions
- Support for both file path and file-like object inputs
- Streaming response capabilities
- MIME type auto-detection for templates

## Implementation Details
- Uses `requests` library for HTTP communications
- Implements proper resource management (auto-closing files)
- Follows Python best practices and PEP 8 guidelines

## Roadmap
- [ ] Add pip package setup
- [ ] Implement comprehensive test suite
- [ ] Add documentation and usage examples
- [ ] CI/CD integration

## Current Status
While the core functionality is implemented and working, this initial version could benefit from community feedback and contributions. The wrapper is already usable for basic integration needs.

@fleebzz Thank you for your collaboration and support with the main Docker API Carbone project. This Python wrapper aims to make Carbone more accessible to the Python community.

## Feedback Welcome
I welcome any suggestions or feedback to improve this implementation, particularly regarding:
- API design choices
- Error handling approaches
- Additional features needed
- Documentation requirements